### PR TITLE
Fix unmount

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -150,7 +150,7 @@ const Shuffle = React.createClass({
   },
 
   componentWillUnmount() {
-    document.body.removeChild(this._portalNode);
+    React.findDOMNode(this.refs.container).removeChild(this._portalNode);
     window.removeEventListener('resize', this._renderClonesInitially);
   },
 


### PR DESCRIPTION
`this._portalNode` was [put](https://github.com/FormidableLabs/react-shuffle/blob/320cb4a9b647ef6c1c71c723986c8201038cb01f/src/shuffle.js#L176) into `this.refs.container`, but in `componentWillUnmount`, `this._portalNode` will be [deleted](https://github.com/FormidableLabs/react-shuffle/blob/320cb4a9b647ef6c1c71c723986c8201038cb01f/src/shuffle.js#L153) from `document.body`. As result, if `this.refs.container !== document.body` we will get a error.

@kenwheeler this issue is very critial for us. Can you accept this fix and release it faster?