### PR TITLE
get cloneWithProps from React.addons

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -2,11 +2,11 @@
 /*global window, document, getComputedStyle*/
 
 import React from 'react/addons';
-import cloneWithProps from 'react/lib/cloneWithProps';
 import assign from 'object-assign';
 import tweenState from 'react-tween-state';
 
 let ReactTransitionGroup = React.addons.TransitionGroup;
+let cloneWithProps = React.addons.cloneWithProps;
 
 const Clones = React.createClass({
   displayName: 'ShuffleClones',


### PR DESCRIPTION
Importing from `react/lib/cloneWithProps` was causing the "Invariant violation" error that is supposed to be caused by two different instances of React being used. When you get the `cloneWithProps` function straight from the imported React, this problem is solved.