### PR TITLE
Use react-motion rather than react-twean-state

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "object-assign": "^4.0.1",
     "react-addons-transition-group": "^0.14.0",
-    "react-tween-state": "^0.1.3"
+    "react-motion": "^0.4.2"
   },
   "peerDependencies": {
     "react": "0.14.x"


### PR DESCRIPTION
I've switched from using [react-twean-state](https://github.com/chenglou/react-tween-state) to [react-motion](https://github.com/chenglou/react-motion) and specifying a `{stiffness, damping}` config instead of a `duration`.

It's helped with interruptions and has reduced the code size significantly.