### PR TITLE
Fix unmounting and context support

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -149,6 +149,7 @@ const Shuffle = React.createClass({
   },
 
   componentWillUnmount() {
+    ReactDom.unmountComponentAtNode(this._portalNode);
     ReactDom.findDOMNode(this.refs.container).removeChild(this._portalNode);
     window.removeEventListener('resize', this._renderClonesInitially);
   },

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -243,12 +243,12 @@ const Shuffle = React.createClass({
       scale: this.props.scale,
       duration: this.props.duration
     });
-    ReactDom.render(<Clones {...cloneProps}/>, this._portalNode);
+    ReactDom.unstable_renderSubtreeIntoContainer(this, <Clones {...cloneProps}/>, this._portalNode);
     this.setState({ready: true});
   },
 
   _renderClones(props, cb) {
-    ReactDom.render(<Clones {...props}/>, this._portalNode, cb);
+    ReactDom.unstable_renderSubtreeIntoContainer(this, <Clones {...props}/>, this._portalNode, cb);
   },
 
   _childrenWithRefs() {


### PR DESCRIPTION
- `ReactDom.unmountComponentAtNode` was never called on the portal element, so children inside it would never have their `componentWillUnmount` method called.
- Uses `ReactDom.unstable_renderSubtreeIntoContainer` instead of `ReactDom.render` so that context is passed to children. Scary name but that mainly seems to apply to context in general and it's what's recommended for this (https://github.com/facebook/react/issues/4081, https://github.com/tajo/react-portal/pull/23). Fixes #11 and #12.
