### PR TITLE
Clearing animation timeout on unmount

### DIFF
--- a/lib/shuffle.js
+++ b/lib/shuffle.js
@@ -171,6 +171,7 @@ var Shuffle = _react2.default.createClass({
     window.addEventListener('resize', this._renderClonesInitially);
   },
   componentWillUnmount: function componentWillUnmount() {
+    clearTimeout(this._timeout);
     _reactDom2.default.unmountComponentAtNode(this._portalNode);
     _reactDom2.default.findDOMNode(this.refs.container).removeChild(this._portalNode);
     window.removeEventListener('resize', this._renderClonesInitially);
@@ -197,7 +198,8 @@ var Shuffle = _react2.default.createClass({
     _reactDom2.default.findDOMNode(this.refs.container).appendChild(this._portalNode);
   },
   _addTransitionEndEvent: function _addTransitionEndEvent() {
-    setTimeout(this._finishAnimation, this.props.duration);
+    clearTimeout(this._timeout);
+    this._timeout = setTimeout(this._finishAnimation, this.props.duration);
   },
   _startAnimation: function _startAnimation(nextProps) {
     var _this3 = this;

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -149,6 +149,7 @@ const Shuffle = React.createClass({
   },
 
   componentWillUnmount() {
+    clearTimeout(this._timeout);
     ReactDom.unmountComponentAtNode(this._portalNode);
     ReactDom.findDOMNode(this.refs.container).removeChild(this._portalNode);
     window.removeEventListener('resize', this._renderClonesInitially);
@@ -177,7 +178,8 @@ const Shuffle = React.createClass({
   },
 
   _addTransitionEndEvent() {
-    setTimeout(this._finishAnimation, this.props.duration);
+    clearTimeout(this._timeout);
+    this._timeout = setTimeout(this._finishAnimation, this.props.duration);
   },
 
   _startAnimation(nextProps) {


### PR DESCRIPTION
Prevents warnings stemming from setState being called when unmounted.