### PR TITLE
Add react 0.14.x and react 15.x compatible dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "object-assign": "^4.0.1",
-    "react-addons-transition-group": "^15.3.0",
+    "react-addons-transition-group": "^15.0.0 || ^0.14.0",
     "react-tween-state": "^0.1.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Adding compatibility support for  `react-addons-transition-group` 

cc @jmcriffey