### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#react-shuffle
+# react-shuffle
 
 Animated shuffling of child components
 
-###Install
+### Install
 
 ```
 npm install react-shuffle
 ```
 
-###Preview
+### Preview
 
 ![http://i.imgur.com/B1RFfvj.gif](http://i.imgur.com/B1RFfvj.gif)
 
@@ -25,7 +25,7 @@ Simply wrap child components with this component and dynamically change them to 
 | scale | React.PropTypes.bool | Should children scale on enter/leave |
 | intial | React.PropTypes.bool | Should scale/fade occur on first load |
 
-###Example
+### Example
 ```javascript
 'use strict';
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
